### PR TITLE
Removed option to not check certs as not needed anymore

### DIFF
--- a/gen_lacells
+++ b/gen_lacells
@@ -21,7 +21,7 @@ fi
 NOW=`date -u "+%Y-%m-%d"`
 FNAME="https://d17pt8qph6ncyq.cloudfront.net/export/MLS-full-cell-export-${NOW}T000000.csv.gz"
 echo "${FNAME}"
-wget --no-check-certificate --output-document=towers_mozilla.csv.gz "${FNAME}"
+wget --output-document=towers_mozilla.csv.gz "${FNAME}"
 gunzip towers_mozilla.csv.gz
 
 #


### PR DESCRIPTION
Seems cloudfront now has valid certs. At least my wget has no problems with this