### PR TITLE
Make configuration & updates (pulls) easier

### DIFF
--- a/gen_lacells
+++ b/gen_lacells
@@ -128,6 +128,21 @@ VACUUM;
 #   Push the new database to the phone. Reboot may not
 #   be required but probably won't hurt.
 #
-echo 'Pushing database to phone'
-adb push lacells.db /sdcard/.nogapps/lacells.db
-#adb reboot
+if [[ $AUTO_PUSH -eq 1 ]]; then
+  ready='y'
+else
+  read -n 1 -p "Ready to push the database to your device? (y/n)" ready
+  echo
+  ready=$(echo $ready | tr [:upper:] [:lower:])
+fi
+
+if [[ "${ready}" != "y" ]]; then
+  echo "Not pushing the database. You can do so manually, executing"
+  echo "   adb push lacells.db /sdcard/.nogapps/lacells.db"
+  echo
+  exit
+else
+  echo 'Pushing database to phone'
+  adb push lacells.db /sdcard/.nogapps/lacells.db
+  #adb reboot
+fi

--- a/gen_lacells
+++ b/gen_lacells
@@ -5,11 +5,26 @@
 #   network location.
 #
 
-# For OpenCellID we need an API key
-API_KEY='put your OpenCellID API key string here'
+# Configure the cell database creator in gen_lacells_conf first
+# An example file can be found in gen_lacells_conf.sample
 
-# Warn user about deleting of cells
-echo "This script automatically deletes cells that are not in North America. If you don't want this to happen, delete or modify the line 'DELETE FROM cells WHERE mcc...'"
+if [[ ! -f gen_lacells_conf ]]; then
+  echo
+  echo 'You have to create your config file first.'
+  echo 'An example config can be found as gen_lacells_conf.sample'
+  echo 'Copy that to gen_lacells_conf and edit it with your data.'
+  echo
+  exit
+fi
+
+. ./gen_lacells_conf
+
+# Shall we restrict the resulting database to configured MCCs?
+if [[ -z "${MCC}" ]]; then
+  PURGE=""
+else
+  PURGE="DELETE FROM cells WHERE mcc NOT IN (${MCC});"
+fi
 
 #
 #   Get latest cell tower data from Mozilla Location Services
@@ -102,7 +117,7 @@ CREATE TEMP TABLE cells_new(radio TEXT, mcc INTEGER, mnc INTEGER, lac INTEGER, c
 .import towers_mozilla.csv cells_new
 INSERT INTO cells SELECT mcc, mnc, lac, cellid, long, lat, -1, min(max(range, 500),100000), max(1,samples) FROM cells_new;
 DROP TABLE cells_new;
-DELETE FROM cells WHERE mcc != 310 AND mcc != 311;
+${PURGE}
 CREATE INDEX _idx1 ON cells (mcc, mnc, lac, cid);
 CREATE INDEX _idx2 ON cells (lac, cid);
 VACUUM;

--- a/gen_lacells_conf.sample
+++ b/gen_lacells_conf.sample
@@ -1,0 +1,9 @@
+# For OpenCellID we need an API key
+API_KEY='put your OpenCellID API key string here'
+
+
+# MCCs to use. This is a comma-separated list of country codes to restrict the
+# resulting database to. Use an empty string if you wish the entire world covered.
+
+# MCC="228,232,262" # DACH (Switzerland, Austria, Germany)
+MCC="310,311"       # USA

--- a/gen_lacells_conf.sample
+++ b/gen_lacells_conf.sample
@@ -7,3 +7,8 @@ API_KEY='put your OpenCellID API key string here'
 
 # MCC="228,232,262" # DACH (Switzerland, Austria, Germany)
 MCC="310,311"       # USA
+
+
+# Shall the resulting DB file be pushed to the device automatically (1), or do you
+# wish to be prompted for that (0)?
+AUTO_PUSH=1

--- a/gen_lacells_merged
+++ b/gen_lacells_merged
@@ -135,6 +135,21 @@ VACUUM;
 #   Push the new database to the phone. Reboot may not
 #   be required but probably won't hurt.
 #
-echo 'Pushing database to phone'
-adb push lacells.db /sdcard/.nogapps/lacells.db
-#adb reboot
+if [[ $AUTO_PUSH -eq 1 ]]; then
+  ready='y'
+else
+  read -n 1 -p "Ready to push the database to your device? (y/n)" ready
+  echo
+  ready=$(echo $ready | tr [:upper:] [:lower:])
+fi
+
+if [[ "${ready}" != "y" ]]; then
+  echo "Not pushing the database. You can do so manually, executing"
+  echo "   adb push lacells.db /sdcard/.nogapps/lacells.db"
+  echo
+  exit
+else
+  echo 'Pushing database to phone'
+  adb push lacells.db /sdcard/.nogapps/lacells.db
+  #adb reboot
+fi

--- a/gen_lacells_merged
+++ b/gen_lacells_merged
@@ -5,8 +5,26 @@
 #   network location.
 #
 
-# For OpenCellID we need an API key
-API_KEY='put your OpenCellID API key string here'
+# Configure the cell database creator in gen_lacells_conf first
+# An example file can be found in gen_lacells_conf.sample
+
+if [[ ! -f gen_lacells_conf ]]; then
+  echo
+  echo 'You have to create your config file first.'
+  echo 'An example config can be found as gen_lacells_conf.sample'
+  echo 'Copy that to gen_lacells_conf and edit it with your data.'
+  echo
+  exit
+fi
+
+. ./gen_lacells_conf
+
+# Shall we restrict the resulting database to configured MCCs?
+if [[ -z "${MCC}" ]]; then
+  PURGE=""
+else
+  PURGE="DELETE FROM cells WHERE mcc NOT IN (${MCC});"
+fi
 
 #
 #   Get latest cell tower data from Mozilla Location Services
@@ -106,7 +124,7 @@ INSERT INTO cells_weighted SELECT mcc, mnc, lac, cellId, long*max(1,samples), la
 DROP TABLE cells_new;
 INSERT INTO cells SELECT mcc, mnc, lac, cid, SUM(longitude)/SUM(samples), SUM(latitude)/SUM(samples), SUM(altitude)/SUM(samples), SUM(accuracy)/SUM(samples), SUM(samples) FROM cells_weighted GROUP BY mcc, mnc, lac, cid;
 DROP TABLE cells_weighted;
-DELETE FROM cells WHERE mcc != 310 AND mcc != 311;
+${PURGE}
 CREATE INDEX _idx1 ON cells (mcc, mnc, lac, cid);
 CREATE INDEX _idx2 ON cells (lac, cid);
 VACUUM;


### PR DESCRIPTION
This pull-request consists of two commits (so you can pick which ones to take).

The first moves all configuration out of the scripts themselves to a separate configuration file. This makes it easier to pull updates, without having to edit anything again. The optional `DELETE` statement is created when MCCs have been defined, and otherwise is replaced by an "empty line".

The second commit adds the option to be prompted for the `adb pull`. As downloading the CSV files and creating the database might take a while (especially on slow connections/computers), this gives the user the chance to use the device without being limited by a cable, and then connect it when the database is ready.

Everything is pre-set to work like it was before the commits. A sample config file is included, having the extension `.sample` added to not overwrite the users' config when pulling updates.