### PR TITLE
changing `AUTO_PUSH` to be able turning it off completely

### DIFF
--- a/gen_lacells
+++ b/gen_lacells
@@ -128,13 +128,15 @@ VACUUM;
 #   Push the new database to the phone. Reboot may not
 #   be required but probably won't hurt.
 #
-if [[ $AUTO_PUSH -eq 1 ]]; then
-  ready='y'
-else
-  read -n 1 -p "Ready to push the database to your device? (y/n)" ready
-  echo
-  ready=$(echo $ready | tr [:upper:] [:lower:])
-fi
+case $AUTO_PUSH in
+  0) ready='n';;
+  1) ready='y';;
+  *)
+    read -n 1 -p "Ready to push the database to your device? (y/n)" ready
+    echo
+    ready=$(echo $ready | tr [:upper:] [:lower:])
+    ;;
+esac
 
 if [[ "${ready}" != "y" ]]; then
   echo "Not pushing the database. You can do so manually, executing"

--- a/gen_lacells_conf.sample
+++ b/gen_lacells_conf.sample
@@ -9,6 +9,6 @@ API_KEY='put your OpenCellID API key string here'
 MCC="310,311"       # USA
 
 
-# Shall the resulting DB file be pushed to the device automatically (1), or do you
-# wish to be prompted for that (0)?
+# Shall the resulting DB file be pushed to the device automatically (1), not at
+# all (0), or do you wish to be prompted for that (2)?
 AUTO_PUSH=1

--- a/gen_lacells_merged
+++ b/gen_lacells_merged
@@ -135,13 +135,15 @@ VACUUM;
 #   Push the new database to the phone. Reboot may not
 #   be required but probably won't hurt.
 #
-if [[ $AUTO_PUSH -eq 1 ]]; then
-  ready='y'
-else
-  read -n 1 -p "Ready to push the database to your device? (y/n)" ready
-  echo
-  ready=$(echo $ready | tr [:upper:] [:lower:])
-fi
+case $AUTO_PUSH in
+  0) ready='n';;
+  1) ready='y';;
+  *)
+    read -n 1 -p "Ready to push the database to your device? (y/n)" ready
+    echo
+    ready=$(echo $ready | tr [:upper:] [:lower:])
+    ;;
+esac
 
 if [[ "${ready}" != "y" ]]; then
   echo "Not pushing the database. You can do so manually, executing"


### PR DESCRIPTION
This way the script can be used e.g. with Cron, and the resulting database can be pushed to multiple devices later, of which at the time of the Cron job none might be connected – and still not result in a Cron error mail.

Example background: I have multiple devices using the cell database. My Android shell tool [Adebar](https://github.com/IzzySoft/Adebar) has a.o. the capability to automatically push files to devices if they are found in corresponding directories. So I could set up a weekly Cron job to create the `lacells.db` and have it copied to the corresponding directories, which would make Adebar transfer them to the device(s) on its next run.