### PR TITLE
fix backup filename.

### DIFF
--- a/gen_lacells
+++ b/gen_lacells
@@ -37,7 +37,7 @@ if [ -e towers_mozilla.csv.gz ] ; then
     rm towers_mozilla.csv.gz
 fi
 if [ -e towers_mozilla.csv ] ; then
-    mv -f towers_mozilla.csv towers_opencellid.csv.bak
+    mv -f towers_mozilla.csv towers_mozilla.csv.bak
 fi
 NOW=`date -u "+%Y-%m-%d"`
 FNAME="https://d17pt8qph6ncyq.cloudfront.net/export/MLS-full-cell-export-${NOW}T000000.csv.gz"


### PR DESCRIPTION
fixing "towers_mozilla.csv" backup name. 
The current backup name is a typo. It deletes mozilla csv backup by overwriting from towers_opencellid.csv.bak" 