### PR TITLE
Config file loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /towers_*.csv.gz
 /lacells/
 /lacells.git/
+/creator.cfg
+/gen_lacells_conf

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ Please note that you can only download the OpenCellID database once per day.
 
 ### Keeping your settings
 
-If you don't want to type the full command over and over again, you can create a simple script in the same directory that you can run instead. Open a text file, and put in the full command preceded by a shebang line:
+To keep you from having to type your `API_KEY` or MCCs each time, this can be specified in a configuration file. It might contain
+
+    API_KEY=xxxx
+    MCC=404,405
+
+Store this as `creator.cfg` in the same directory as the script, or in `~/.config/lacells/creator.cfg`. The script will then pick up these defaults automatically (but you can still override the MCCs on the command-line).
+
+If you'd like to use multiple configurations, please look at the command-line option `-C` or `--config`.
+
+
+### Using your own script
+
+To automate it even further, you could create a simple script in the same directory that you can run instead. Open a text file, and put in the full command preceded by a shebang line:
 
     #!/bin/sh
     API_KEY=xxx ./lacells-creator -d -i -c 404,405 -m -p

--- a/lacells-creator
+++ b/lacells-creator
@@ -20,12 +20,20 @@ help() {
   exit
 }
 
-ARGS=$(getopt -o dic:mpehq -l "download,import,filter-mcc:,merge,push,push-now,export,help,quiet" -n `basename $0` -- "$@")
-eval set -- "$ARGS"
-
+# Variables first so that settings could override them, even though this is
+# unsupported because they can change in future versions.
 QUIET=
 ACTIONS=""
 FILTER="1=1"
+
+# Read default configuration files, then those specified on the command-line.
+config_default "$PREFIX"
+config_from_options $@
+
+# Parse command-line arguments (after settings so they can be overridden).
+ARGS=$(getopt -o dic:mpeC:hq -l "download,import,filter-mcc:,merge,push,push-now,export,config:,help,quiet" -n `basename $0` -- "$@")
+eval set -- "$ARGS"
+
 while true; do
   case "$1" in
     -d|--download)
@@ -56,6 +64,10 @@ while true; do
     -e|--export)
       ACTIONS="$ACTIONS export"
       shift
+      ;;
+    -C|--config)
+      # already handled in first pass
+      shift 2
       ;;
     -h|--help)
       help

--- a/lacells-creator
+++ b/lacells-creator
@@ -115,3 +115,5 @@ if [[ "$ACTIONS" =~ pushask ]]; then
 else
   [[ "$ACTIONS" =~ pushnow ]] && lacells_push_now
 fi
+
+exit 0

--- a/lacells-creator
+++ b/lacells-creator
@@ -21,9 +21,10 @@ help() {
 }
 
 # Variables first so that settings could override them, even though this is
-# unsupported because they can change in future versions.
+# unsupported because they may change in future versions.
+MCC=
 QUIET=
-ACTIONS=""
+ACTIONS=
 FILTER="1=1"
 
 # Read default configuration files, then those specified on the command-line.
@@ -31,7 +32,7 @@ config_default "$PREFIX"
 config_from_options $@
 
 # Parse command-line arguments (after settings so they can be overridden).
-ARGS=$(getopt -o dic:mpeC:hq -l "download,import,filter-mcc:,merge,push,push-now,export,config:,help,quiet" -n `basename $0` -- "$@")
+ARGS=$(getopt -o dic::mpeC:hq -l "download,import,filter-mcc::,merge,push,push-now,export,config:,help,quiet" -n `basename $0` -- "$@")
 eval set -- "$ARGS"
 
 while true; do
@@ -46,7 +47,7 @@ while true; do
       ;;
     -c|--filter-mcc)
       ACTIONS="$ACTIONS filter"
-      FILTER="$FILTER AND mcc IN ($2)"
+      [ "$2" ] && MCC="$2"
       shift 2
       ;;
     -m|--merge)
@@ -84,10 +85,25 @@ while true; do
   esac
 done
 
+# Pre-process variables
+
+if [ "$MCC" ]; then
+  FILTER="$FILTER AND mcc IN ($MCC)"
+fi
+
+# Check actions
+
 if [ -z "$ACTIONS" ]; then
   error "Nothing to do, please supply an action."
   help
 fi
+
+if [[ "$ACTIONS" =~ filter ]] && [ ! "$MCC" ]; then
+  echo "Please give one or more MCCs to filter." 1>&2
+  exit 1
+fi
+
+# Execute actions
 
 [[ "$ACTIONS" =~ download ]] && download
 if echo "$ACTIONS" | grep -q 'import\|filter\|combine\|export'; then

--- a/lib/config
+++ b/lib/config
@@ -1,24 +1,50 @@
 #!/bin/bash
 #
-# Default configuration for lacells-creator
-#
-# This file must sourced when using any other shellscript library file.
-# Before sourcing this file, please set PREFIX to the source location.
+# Read and parse lacells configuration
 #
 # Licensed under GPLv3 or later
-# (c)2015 wvengen & n76
+# (c)2015 wvengen
 
-# Data directory
-DATA_DIR=.
+# read configuration files from options
+config_from_options() {
+  local ARGS
+  ARGS=$(getopt -q -o C: -l config: -- "$@")
+  eval set -- "$ARGS"
+  while true; do
+    case "$1" in
+      -C|--config)
+        config_read "$2"
+        shift
+        ;;
+      --)
+        break
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+}
 
-# Main lacells database
-LACELLS_DB="${DATA_DIR}/lacells.db"
-# Output directory with cell location CSVs per MCC
-LACELLS_DIR="${DATA_DIR}/lacells"
+# read configuration file given
+config_read() {
+  if [ -r "$1" ]; then
+    source "$1"
+  else
+    echo "WARNING: Cannot read configuration file '$1', skipped." 1>&2
+  fi
+}
 
-# Git repository for uploading
-LACELLS_GIT_DIR="${DATA_DIR}/lacells.git"
+# read configuration file given when it exists
+config_try_read() {
+  [ -e "$1" ] && config_read "$1"
+}
 
-# OpenCellID API Key. Obviously, there is no default.
-#API_KEY=
+# read default configuration files; give PREFIX as argument
+config_default() {
+  config_read "$1/misc/creator.cfg"
+  config_try_read "${XDG_CONFIG_HOME:-$HOME/.config}/lacells/creator.cfg"
+  config_try_read "$1/gen_lacells_conf"
+  config_try_read "$1/creator.cfg"
+}
 

--- a/lib/download
+++ b/lib/download
@@ -3,7 +3,7 @@
 # Download cell tower databases from OpenCellID & Mozilla Location Service
 #
 # You need to set API_KEY to an OpenCellID API key
-# Make sure you've sourced `config` and `util` before running any function.
+# Make sure you've sourced `config` and `util` and run `config_default`.
 #
 # Licensed under GPLv3 or later
 # (c)2015 wvengen & n76

--- a/lib/process
+++ b/lib/process
@@ -3,7 +3,7 @@
 # Build cell tower databases from OpenCellID & Mozilla Location Service
 #
 # These can be imported into a microg/nogapps network location provider app.
-# Make sure you've sourced `config` and `util` before running any function.
+# Make sure you've sourced `config` and `util` and run `config_default`.
 #
 # Licensed under GPLv3 or later
 # (c)2015 wvengen & n76

--- a/lib/push
+++ b/lib/push
@@ -2,7 +2,7 @@
 #
 # Push lacells.db to Android device
 #
-# Make sure you've sourced `config` and `util` before running any function.
+# Make sure you've sourced `config` and `util` and run `config_default`.
 #
 # Licensed under GPLv3 or later
 # (c)2015 wvengen & n76

--- a/misc/creator.cfg
+++ b/misc/creator.cfg
@@ -1,0 +1,26 @@
+#
+# Default configuration for lacells-creator
+#
+
+### User settings (unset by default)
+
+# OpenCellID API key.
+#API_KEY=
+
+# Set to 'y' to be more silent on normal operation.
+#QUIET=
+
+
+### Default file locations
+
+# Data directory
+DATA_DIR=.
+
+# Main lacells database
+LACELLS_DB="${DATA_DIR}/lacells.db"
+# Output directory with cell location CSVs per MCC
+LACELLS_DIR="${DATA_DIR}/lacells"
+
+# Git repository for uploading
+LACELLS_GIT_DIR="${DATA_DIR}/lacells.git"
+

--- a/misc/creator.cfg
+++ b/misc/creator.cfg
@@ -7,6 +7,9 @@
 # OpenCellID API key.
 #API_KEY=
 
+# Comma-separated list of country codes to keep in the database when filtering.
+#MCC=
+
 # Set to 'y' to be more silent on normal operation.
 #QUIET=
 

--- a/misc/upload-git
+++ b/misc/upload-git
@@ -57,3 +57,4 @@ if [ `basename $0` = upload-git ]; then
   upload
 fi
 
+exit 0

--- a/misc/upload-git
+++ b/misc/upload-git
@@ -1,7 +1,7 @@
 #
 # Update remote git(hub) repository with lacells-creator results
 #
-# Make sure you've sourced `config` and `util` before running any function
+# Make sure you've sourced `config` and `util` and run `config_default`
 # when using this as a library.
 #
 # Licensed under GPLv3 or later
@@ -49,10 +49,11 @@ upload() {
 
 # Main program
 if [ `basename $0` = upload-git ]; then
-  # expects to be run from misc/upload-github
+  # expects to be run from misc/upload-git
   PREFIX="`dirname $0`/.."
   source "$PREFIX/lib/config"
   source "$PREFIX/lib/util"
+  config_default "$PREFIX"
   upload
 fi
 

--- a/misc/upload-git
+++ b/misc/upload-git
@@ -54,6 +54,7 @@ if [ `basename $0` = upload-git ]; then
   source "$PREFIX/lib/config"
   source "$PREFIX/lib/util"
   config_default "$PREFIX"
+  config_from_options $@
   upload
 fi
 

--- a/misc/usage.txt
+++ b/misc/usage.txt
@@ -11,9 +11,10 @@ Options:
           Import towers_(...).csv into the lacells.db file. When lacells.db
           is already present, it is moved to lacells.db.bak first.
 
-  -c <MCC>, --filter-mcc <MCC>
+  -c[<MCC>], --filter-mcc[=<MCC>]
           Only keep records in lacells.db that have the specified MCC
           (mobile country code). Use comma-separated list for multiple.
+          When no MCCs are given, the default configuration's MCC is used.
 
   -m, --merge
           Merge records from duplicate cell towers in lacells.db.
@@ -50,11 +51,11 @@ Configuration:
 Examples:
 
   Download, import, filter on Zimbabwe, merge and push to mobile:
-     API_KEY=xxx ./lacells-creator -d -i -c 648 -m -p
+     API_KEY=xxx ./lacells-creator -d -i -c648 -m -p
 
   With files downloaded before, generate lacells.db for India:
-    ./lacells-creator -i -c 404,405 -m
+    ./lacells-creator -i -c404,405 -m
 
   Generate CSV files for a number of countries:
-    ./lacells-creator -i -c 605,641,645,748 -e
+    ./lacells-creator -i -c605,641,645,748 -e
 

--- a/misc/usage.txt
+++ b/misc/usage.txt
@@ -26,11 +26,26 @@ Options:
           Export lacells.db to CSVs per MCC to lacells/lacells-mcc_xxx.csv
           and a country summary in lacells/lacells-countries.{csv,geojson}.
 
+  -C <file>, --config <file>
+          Read configuration file. If this option appears multiple times,
+          files are loaded in order, before all other command-line options.
+
   -h, --help
           Show this help message.
 
   -q, --quiet
           Don't tell what's happening, only report errors.
+
+Configuration:
+
+  The default user configuration is read from ~/.config/lacells/creator.cfg
+  and the file gen_lacells_conf or creator.cfg in the script's location.
+  After that, any configuration files specified on the command-line are read.
+
+  A configuration file can set variables in use by the script. Usually, you
+  would set API_KEY to the OpenCellID's key, and MCC to a comma-separated
+  list of mobile country codes.
+  For all possible options, please see misc/creator.cfg.
 
 Examples:
 


### PR DESCRIPTION
After a discussion in #13, this is the result.
In addition to the proposal there, this also reads `gen_lacells_conf` for backward-compatibility (though the adb push configuration is not recognised).