### PR TITLE
updatet link to cell_towers.csv.gz and changed order of download requests

### DIFF
--- a/lib/download
+++ b/lib/download
@@ -40,11 +40,11 @@ download_opencellid() {
 		echo "Please set API_KEY to download OpenCellID data" 1>&2
 		exit
 	fi
-	_download_from opencellid "http://opencellid.org/downloads/?apiKey=${API_KEY}&filename=cell_towers.csv.gz"
+	_download_from opencellid "https://opencellid.org/ocid/downloads?token=${API_KEY}&type=full&file=cell_towers.csv.gz"
 }
 
 download() {
-  download_mozilla
   download_opencellid
+  download_mozilla
 }
 


### PR DESCRIPTION
I updated the link to the cell_towers.csv.gz file, because the old one was not working.
I changed the sequential arrangement of the downloads so that an error while downloading form OpenCellID (e. g. wrong API key or wrong URL) fails first. Otherwise one always had to wait for the download from mozilla and start it over an over again.

